### PR TITLE
KUBOS-141 Lowered baud rate for better consistency + more data

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
     	"SDIO": {},
         "console": {
             "uart": "K_UART2",
-            "baudRate": "115200"
+            "baudRate": "57600"
         },
         "uartDefaults": {
             "txQueueLen": 128,

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "ukub-sensor-node",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "bin": "./source",
   "description": "Sensor node for ukub mission.",
   "repository": {
@@ -11,6 +11,6 @@
   "license": "Apache-2.0",
   "bin" : "./source",
   "dependencies": {
-      "kubos-rt" : "openkosmosorg/kubos-rt#~0.0.1"
+      "kubos-rt" : "kubostech/kubos-rt#~0.1.0"
   }
 }

--- a/source/main.c
+++ b/source/main.c
@@ -64,11 +64,11 @@ void displayCalStatus(void)
     }
 
     /* Display the individual values */
-    printf("S: %d G: %d %d|%d|%d A: %d %d|%d|%d|%d M: %d %d|%d|%d|%d\r\n",
+    printf("S: %d G: %d A: %d M: %d \r\n",
         calib.sys,
-		calib.gyro, offsets.gyro_offset_x, offsets.gyro_offset_y, offsets.gyro_offset_z,
-		calib.accel, offsets.accel_offset_x, offsets.accel_offset_y, offsets.accel_offset_z, offsets.accel_radius,
-		calib.mag, offsets.mag_offset_x, offsets.mag_offset_y, offsets.mag_offset_z, offsets.mag_radius
+		calib.gyro,
+		calib.accel,
+		calib.mag
     );
 }
 
@@ -88,7 +88,6 @@ uint16_t close_file(FIL * Fil)
 {
 	uint16_t ret;
 	ret = f_close(Fil);
-	printf("Close RC: %d\r\n", ret);
 	return ret;
 }
 
@@ -252,6 +251,9 @@ void task_sensors(void *p)
     float hum = 0;
     bno055_quat_data_t quat_data;
     bno055_vector_data_t eul_vector;
+    bno055_vector_data_t grav_vector;
+    bno055_vector_data_t lin_vector;
+    bno055_vector_data_t acc_vector;
     uint32_t time_ms;
     static char msg[255];
     uint8_t count = 1;
@@ -280,6 +282,8 @@ void task_sensors(void *p)
             htu21d_read_temperature(&temp);
             blink(K_LED_ORANGE);
             htu21d_read_temperature(&temp);
+            blink(K_LED_ORANGE);
+            displayCalStatus();
 
             //Check status of calibration
             oldCount = calibCount;
@@ -305,6 +309,7 @@ void task_sensors(void *p)
 
             count = 1;
         }
+
         if (bno_stat != I2C_OK && bno_stat != SENSOR_NOT_CALIBRATED)
         {
         	printf("bno_stat = %d\r\n", bno_stat);
@@ -320,15 +325,22 @@ void task_sensors(void *p)
             bno055_get_position(&quat_data);
             blink(K_LED_ORANGE);
             bno055_get_data_vector(VECTOR_EULER, &eul_vector);
+            blink(K_LED_ORANGE);
+            bno055_get_data_vector(VECTOR_GRAVITY, &grav_vector);
+            blink(K_LED_ORANGE);
+            bno055_get_data_vector(VECTOR_LINEARACCEL, &lin_vector);
+            blink(K_LED_ORANGE);
+            bno055_get_data_vector(VECTOR_ACCELEROMETER, &acc_vector);
 
         }
 
-        displayCalStatus();
-
-        sprintf(msg, "%d|%3.2f|%3.2f|%f|%f|%f|%f|%f|%f|%f\r\n",
+        sprintf(msg, "%d|%3.2f|%3.2f|%f|%f|%f|%f|%f|%f|%f|%f|%f|%f|%f|%f|%f|%f|%f|%f\r\n",
             time_ms, temp, hum,
             quat_data.w, quat_data.x, quat_data.y, quat_data.z,
-            eul_vector.x, eul_vector.y, eul_vector.z
+            eul_vector.x, eul_vector.y, eul_vector.z,
+            grav_vector.x, grav_vector.y, grav_vector.z,
+            lin_vector.x, lin_vector.y, lin_vector.z,
+            acc_vector.x, acc_vector.y, acc_vector.z
         );
         k_uart_write(K_UART_CONSOLE, msg, strlen(msg));
         blink(K_LED_GREEN);

--- a/source/main.c
+++ b/source/main.c
@@ -105,7 +105,7 @@ void displayCalStatus(void)
     }
 
 /* Display the individual values */
-    printf("S:\t%d\tG:\t%d\tA:\t%di\tM:\t%d\r\n",
+    printf("S:\t%d\tG:\t%d\tA:\t%d\tM:\t%d\r\n",
         calib.sys,
 		calib.gyro,
 		calib.accel,


### PR DESCRIPTION
Lowered the baud rate from 115200 to 57600 to decrease number of squashed log lines.
Additionally added data read calls to get actual position data.